### PR TITLE
RebootVM method in virtlet runtime service

### DIFF
--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -18,10 +18,9 @@ package libvirttools
 
 import (
 	"fmt"
-
 	"github.com/golang/glog"
-	libvirt "github.com/libvirt/libvirt-go"
-	libvirtxml "github.com/libvirt/libvirt-go-xml"
+	"github.com/libvirt/libvirt-go"
+	"github.com/libvirt/libvirt-go-xml"
 
 	"github.com/Mirantis/virtlet/pkg/virt"
 )
@@ -251,4 +250,8 @@ func (secret *libvirtSecret) SetValue(value []byte) error {
 
 func (secret *libvirtSecret) Remove() error {
 	return secret.s.Undefine()
+}
+
+func (domain *libvirtDomain) Reboot(flags libvirt.DomainRebootFlagValues) error {
+	return domain.d.Reboot(flags)
 }

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -969,3 +969,17 @@ func filterContainer(containerInfo *types.ContainerInfo, filter types.ContainerF
 
 	return true
 }
+
+func (v *VirtualizationTool) RebootVM(vmID string) error {
+	domain, err := v.domainConn.LookupDomainByUUIDString(vmID)
+	if err != nil {
+		return  err
+	}
+
+	// TODO: fix to use the flag from RebootVmRequest
+	// just take the default for now
+	// https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainRebootFlagValues
+	domain.Reboot(0)
+
+	return nil
+}

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -549,3 +549,15 @@ func validatePodSandboxConfig(config *kubeapi.PodSandboxConfig) error {
 
 	return nil
 }
+
+// RebootVM method implements RebootVM() from CRI
+func (v *VirtletRuntimeService) RebootVM(ctx context.Context, in *kubeapi.RebootVMRequest) (*kubeapi.RebootVMResponse, error) {
+	glog.V(2).Infof("Rebooting VM %s", in.VmId)
+	if err := v.virtTool.RebootVM(in.VmId); err != nil {
+		glog.Errorf("RebootVM failed with error: %v", err)
+		return nil, err
+	}
+	glog.V(2).Infof("Successfully Rebooted VM %s", in.VmId)
+	response := &kubeapi.RebootVMResponse{}
+	return response, nil
+}

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
+	libvirt "github.com/libvirt/libvirt-go"
 )
 
 const (
@@ -109,4 +110,6 @@ type Domain interface {
 	GetRSS() (uint64, error)
 	// GetCPUTime returns cpu time used by VM in nanoseconds per core
 	GetCPUTime() (uint64, error)
+	// RebootVM reboots the VM
+	Reboot(libvirt.DomainRebootFlagValues) error
 }


### PR DESCRIPTION
Reboot method support in Virtlet based CRI runtime service.
Note that refactor the runtime services for vm operations will be in different effort.