### PR TITLE
Implement CreateSnapshot() and RestoreToSnapshot() CRI methods

### DIFF
--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -973,7 +973,7 @@ func filterContainer(containerInfo *types.ContainerInfo, filter types.ContainerF
 func (v *VirtualizationTool) RebootVM(vmID string) error {
 	domain, err := v.domainConn.LookupDomainByUUIDString(vmID)
 	if err != nil {
-		return  err
+		return err
 	}
 
 	// TODO: fix to use the flag from RebootVmRequest
@@ -982,4 +982,22 @@ func (v *VirtualizationTool) RebootVM(vmID string) error {
 	domain.Reboot(0)
 
 	return nil
+}
+
+func (v *VirtualizationTool) CreateSnapshot(vmID string, snapshotID string) error {
+	domain, err := v.domainConn.LookupDomainByUUIDString(vmID)
+	if err != nil {
+		return err
+	}
+
+	return domain.CreateSnapshot(snapshotID)
+}
+
+func (v *VirtualizationTool) RestoreToSnapshot(vmID string, snapshotID string) error {
+	domain, err := v.domainConn.LookupDomainByUUIDString(vmID)
+	if err != nil {
+		return err
+	}
+
+	return domain.RestoreToSnapshot(snapshotID)
 }

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -19,8 +19,8 @@ package virt
 import (
 	"errors"
 
-	libvirtxml "github.com/libvirt/libvirt-go-xml"
 	libvirt "github.com/libvirt/libvirt-go"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 const (
@@ -112,4 +112,8 @@ type Domain interface {
 	GetCPUTime() (uint64, error)
 	// RebootVM reboots the VM
 	Reboot(libvirt.DomainRebootFlagValues) error
+	// CreateSnapshot creates a system snapshot of the current domain
+	CreateSnapshot(string) error
+	// RestoreToSnapshot restores current domain to the specified snapshot
+	RestoreToSnapshot(string) error
 }


### PR DESCRIPTION
This PR adds the implementation of two new CRI methods for VM:  CreateSnapshot and RestoreToSnapshot.  

At first I planned to persist the snapshot IDs. But it seems not necessary: 1) the name is already enforced to be unique under one domain object . 2) Snapshot lookup will check if a valid name is provided for the restore(revert) operations.

Manually tested with the actions "Snapshot" and "Restore" in Alkaid.