### PR TITLE
Rename project name from Alkaid to Arktos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing guidelines
 
-Please follow the general [guidelines](https://github.com/futurewei-cloud/alkaid/blob/master/CONTRIBUTING.md) described in Alkaid project.
+Please follow the general [guidelines](https://github.com/futurewei-cloud/alkaid/blob/master/CONTRIBUTING.md) described in Arktos project.
 
 ### Contributing A Patch
 
 1. Fork the desired repo, develop and test your code changes.
-1. Verify that your code changes follows Alkaid contributor guidelines
+1. Verify that your code changes follows Arktos contributor guidelines
 1. Submit a pull request.
 
 ### Adding dependencies

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# ALKAID-VM-RUNTIME
+# ARKTOS-VM-RUNTIME
 
-Alkaid-vm-runtime is a runtime service for [Alkaid](https://github.com/futurewei-cloud/alkaid) cluster to run VM workloads.
+Arktos-vm-runtime is a runtime service for [Arktos](https://github.com/futurewei-cloud/alkaid) cluster to run VM workloads.
 
-Alkaid-vm-runtime implements the extended CRI interface defined in Alkaid cluster to support VM workloads. It is based 
+Arktos-vm-runtime implements the extended CRI interface defined in Arktos cluster to support VM workloads. It is based 
 on and evolved from [Mirantis Virtlet project](https://github.com/Mirantis/virtlet) with  the extension to current CRI 
 interface implementation.
 
 ## Major features
 ### Support for VM workload specific operations
-Alkaid-vm-runtime extends the current CRI interfaces with initial set of methods to support VM operations, as listed below:
+Arktos-vm-runtime extends the current CRI interfaces with initial set of methods to support VM operations, as listed below:
 
 	// RebootVM reboots the VM domain and returns error msg if there is any
 	RebootVM(ctx context.Context, in *RebootVMRequest, opts ...grpc.CallOption) (*RebootVMResponse, error)
@@ -24,26 +24,26 @@ Alkaid-vm-runtime extends the current CRI interfaces with initial set of methods
 	ListNetworkInterfaces(ctx context.Context, in *ListDeviceRequest, opts ...grpc.CallOption) (*ListDeviceResponse, error)
 
 ### VM centric runtime service
-Alkaid supports VM workload and multiple tenants natively. As a runtime service designed to support Alkaid, Alkaid-vm-runtime 
-bridges the NICs/VPCs from the Alkaid node agent to the CNI, with extension to the current CRI's PodSandboxConfig with 
-new VPC and NICs fields. Alkaid runtime also retrieves information for other VM specific elements such as TTY, CloudInit etc.
+Arktos supports VM workload and multiple tenants natively. As a runtime service designed to support Arktos, Arktos-vm-runtime 
+bridges the NICs/VPCs from the Arktos node agent to the CNI, with extension to the current CRI's PodSandboxConfig with 
+new VPC and NICs fields. Arktos runtime also retrieves information for other VM specific elements such as TTY, CloudInit etc.
 from the virtual machine workload definition to the underlying Libvirt component for those VM specific features.
 
 
-## Build and publish Alkaid-vm-runtime images
-Alkaid-vm-runtime inherits Virtlet's build logic, with addition to publish the runtime docker images with specific tags.
-For example, the following commands will build the Alkaid-vm-runtime docker image and publish it to docker repo with
+## Build and publish Arktos-vm-runtime images
+Arktos-vm-runtime inherits Virtlet's build logic, with addition to publish the runtime docker images with specific tags.
+For example, the following commands will build the Arktos-vm-runtime docker image and publish it to docker repo with
 tag "0.5.2"
 
      ./build/cmd.sh build/
      ./build/cmd.sh publish "0.5.2"
 
-## Using Alkaid-vm-runtime with Alkaid cluster for VM type
-Alkaid is fully automated to use the Alkaid-vm-runtime as default VM runtime service. The alkaid-up.sh in the Alkaid 
-project can be used to start a onebox Alkaid cluster and use Alkaid-vm-runtime for VM type workload.
+## Using Arktos-vm-runtime with Arktos cluster for VM type
+Arktos is fully automated to use the Arktos-vm-runtime as default VM runtime service. The Arktos-up.sh in the Arktos 
+project can be used to start a onebox Arktos cluster and use Arktos-vm-runtime for VM type workload.
 
 ## Work in progress
-The Alkaid-vm-runtime is still in its early stage. There are quite a few efforts planned in order to make this a complete 
+The Arktos-vm-runtime is still in its early stage. There are quite a few efforts planned in order to make this a complete 
 runtime service for VM workloads. 
 1. Support More VM actions
 2. Simplify the networking design

--- a/build/api.pb.go
+++ b/build/api.pb.go
@@ -1,6 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -21,7 +21,7 @@ MKDOCS_SERVE_ADDRESS="${MKDOCS_SERVE_ADDRESS:-localhost:8042}"
 
 # Note that project_dir must not end with slash
 project_dir="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd)"
-virtlet_image="alkaidstaging/vmruntime"
+virtlet_image="arktosstaging/vmruntime"
 remote_project_dir="/go/src/github.com/Mirantis/virtlet"
 build_name="virtlet_build"
 tmp_container_name="${build_name}-$(openssl rand -hex 16)"

--- a/build/custom-boilerplate.go.txt
+++ b/build/custom-boilerplate.go.txt
@@ -1,6 +1,6 @@
 /*
 Copyright YEAR Mirantis
-Copyright YEAR Authors of Alkaid – file modified
+Copyright YEAR Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build/importDockerImageForCRI.sh
+++ b/build/importDockerImageForCRI.sh
@@ -3,7 +3,7 @@
 WORKING_DIR=/tmp/containerd
 CRI_CONFIG_FILE=${WORKING_DIR}/etc/crictl.yaml
 CONTAINERD_SOCK_PATH="/run/containerd/containerd.sock"
-DOCKER_IMAGE_NAME="alkaidstaging/vmruntime:latest"
+DOCKER_IMAGE_NAME="arktosstaging/vmruntime:latest"
 LOCAL_IMAGE_FILE="localimage.tar"
 
 if ! systemctl is-active --quiet containerd; then

--- a/docs/docs/dev/guidelines.md
+++ b/docs/docs/dev/guidelines.md
@@ -4,7 +4,7 @@ Be professional. When it's possible - follow general golang [code review guideli
 
 ## Contributing guidelines
 
-Please follow the general [guidelines](https://github.com/futurewei-cloud/alkaid/blob/master/CONTRIBUTING.md) described in Alkaid project.
+Please follow the general [guidelines](https://github.com/futurewei-cloud/alkaid/blob/master/CONTRIBUTING.md) described in Arktos project.
 ## Filing issues
 
 Consider adding issue to our [issue tracker](https://github.com/futurewei-cloud/alkaid-vm-runtime/issues) if you will find any deviation from this rules in our existing code

--- a/images/Dockerfile.virtlet
+++ b/images/Dockerfile.virtlet
@@ -4,8 +4,8 @@
 FROM mirantis/virtlet-base:v1-6348ee2277c565d3895260bccb5ada96
 MAINTAINER Ivan Shvedunov <ishvedunov@mirantis.com>
 
-LABEL alkaidstaging.image="alkaidstaging"
-LABEL alkaidstaging.build="internal"
+LABEL arktosstaging.image="arktosstaging"
+LABEL arktosstaging.build="internal"
 
 COPY image_skel /.
 COPY _output/flexvolume_driver /

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2016 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2016-2017 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2016-2018 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/tapmanager/tapfdsource.go
+++ b/pkg/tapmanager/tapfdsource.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 Mirantis
-Copyright 2020 Authors of Alkaid – file modified
+Copyright 2020 Authors of Arktos – file modified
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Renamed the project name from Alkaid to Arktos except the links to the Alkaid project.