### PR TITLE
Enable apparmor in standalone deployment

### DIFF
--- a/deploy/apparmor/libvirtd
+++ b/deploy/apparmor/libvirtd
@@ -65,8 +65,9 @@ profile libvirtd flags=(attach_disconnected) {
   /etc/xen/scripts/** rmix,
   /usr/lib/libvirt/* PUxr,
   /usr/sbin/libvirtd rix,
+  /sys/kernel/security/apparmor/profiles r,
 
-	/sys/kernel/security/apparmor/profiles r,
-
+  /var/log/virtlet/** rw,
   /vmwrapper rix,
+  /libvirt.sh rix,
 }

--- a/deploy/apparmor/virtlet
+++ b/deploy/apparmor/virtlet
@@ -52,6 +52,7 @@ profile virtlet flags=(attach_disconnected) {
   /run/secrets/kubernetes.io/** rw,
   /var/log/pods/** rw,
   /{var/,}tmp/{,**} rw,
+  /var/log/virtlet/** rw,
 
   @{PROC}/@{pid}/mountinfo r,
   @{PROC}/@{pid}/net/psched r,
@@ -73,6 +74,7 @@ profile virtlet flags=(attach_disconnected) {
 
   /run/mount/* rw,
 
+  /bin/bash ix,
   /bin/mount rwix,
   /bin/mount/** wrcix,
   /dev/mapper/** rw,
@@ -84,6 +86,8 @@ profile virtlet flags=(attach_disconnected) {
   /sys/devices/virtual/net/br*/bridge/ageing_time rw,
   /sys/bus/pci/devices/ r,
   /sys/bus/pci/devices/*/driver/unbind w,
+  /sys/devices/virtual/block/** rw,
+  /dev/** rw,
 
   /sbin/* ix,
   /run/* rcxwk,
@@ -91,5 +95,5 @@ profile virtlet flags=(attach_disconnected) {
   /var/lib/cni/networks/** rcxwk,
   /etc/resolv.conf rw,
   /etc/libvirt/* rw,
-  /start.sh r,
+  /start.sh rix,
 }

--- a/deploy/apparmor/vms
+++ b/deploy/apparmor/vms
@@ -11,6 +11,13 @@ profile vms flags=(attach_disconnected) {
   /{usr/,}bin/cut rix,
   /{var/,}tmp/{,**} r,
 
+  /etc/resolv.conf rw,
+  /etc/bash.bashrc r,
+  /root/.bashrc r,
+  /etc/inputrc r,
+
+  /bin/bash ix,
+  /var/log/virtlet/** rw,
   /var/lib/virtlet/vms.procfile w,
   /vms.sh rix,
 


### PR DESCRIPTION
This PR contains the apparmor support for the standalone, docker based deployment for VM runtime service, along an option for not-overwriting existing apparmor etc deployment related files.

Locally tested on dev machine.