### PR TITLE
create new cg for vm process. vm cg layout to match containers

### DIFF
--- a/build/cmd.sh
+++ b/build/cmd.sh
@@ -402,6 +402,19 @@ function build_image_internal {
 function install_vendor_internal {
     if [ ! -d vendor ]; then
         glide install --strip-vendor
+
+        # handle a few cases
+        pushd /go/src/github.com/Mirantis/virtlet/vendor/github.com/coreos/
+        mkdir v22
+        cp -r ./go-systemd/* ./v22/
+        mv v22 ./go-systemd/
+        popd
+
+        pushd /go/src/github.com/Mirantis/virtlet/vendor/github.com/godbus/
+        mkdir v5
+        cp -r ./dbus/* ./v5/
+        mv v5 ./dbus/
+        popd
     fi
 }
 

--- a/deploy/apparmor/virtlet
+++ b/deploy/apparmor/virtlet
@@ -89,6 +89,10 @@ profile virtlet flags=(attach_disconnected) {
   /sys/devices/virtual/block/** rw,
   /dev/** rw,
 
+  /sys/fs/cgroup/** rwcx,
+  /sys/kernel/** rw,
+  /sys/kernel/mm/hugepages/* rw,
+  /proc/** rw,
   /sbin/* ix,
   /run/* rcxwk,
   /proc/sys/net/** rwix,

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,12 @@
 hash: 570ae013eb3ccd8485245bc75a71526b9a31594d9663bb84d79886ee011f4f1c
 updated: 2020-06-17T23:28:48.585102907Z
 imports:
+- name: github.com/opencontainers/runtime-spec
+  version: 8e2f17c5a40b7649c3a9bf262e7723ad85929761
+- name: github.com/containerd/cgroups
+  version: 350791b421edcf85ccb9fbc68487c1a22d788c6f
+- name: github.com/godbus/dbus
+  version: 66d97aec3384421e393c2a76b770a1b5c31d07a8
 - name: github.com/aykevl/osfs
   version: e4b1ff739ec92f420bca98d909fffb71fc68e29c
 - name: github.com/boltdb/bolt
@@ -16,7 +22,7 @@ imports:
   - pkg/types/current
   - pkg/version
 - name: github.com/coreos/go-systemd
-  version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
+  version: 2d78030078ef61b3cae27f42ad6d0e46db51b339
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -94,7 +100,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 5628607bb4c51c3157aacc3a50f0ab707582b805
   subpackages:
   - gogoproto
   - proto

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,5 @@
 package: github.com/Mirantis/virtlet
 import:
-- package: github.com/coreos/go-systemd
-  version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
 - package: github.com/golang/glog
 - package: golang.org/x/net
   version: 0ed95abb35c445290478a5348a7b38bb154135fd
@@ -47,7 +45,7 @@ import:
 - package: github.com/spf13/cobra
   version: a1f051bc3eba734da4772d60e2d677f47cf93ef4
 - package: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: v1.3.1
 - package: github.com/renstrom/dedent
   version: ^1.0.0
 - package: github.com/russross/blackfriday
@@ -86,3 +84,17 @@ import:
   version: e4b1ff739ec92f420bca98d909fffb71fc68e29c
 - package: github.com/kballard/go-shellquote
   version: 95032a82bc518f77982ea72343cc1ade730072f0
+- package: github.com/opencontainers/runtime-spec
+  version: 8e2f17c5a40b7649c3a9bf262e7723ad85929761
+- package: github.com/containerd/cgroups
+  version: 350791b421edcf85ccb9fbc68487c1a22d788c6f
+- package: github.com/coreos/go-systemd
+  version: v22.0.0
+- package: github.com/godbus/dbus
+  version: v5.0.0
+- package: github.com/gogo/protobuf
+  version: v1.3.1
+  subpackages:
+  - proto
+  - gogoproto
+                    

--- a/pkg/utils/cgroups/controllers.go
+++ b/pkg/utils/cgroups/controllers.go
@@ -18,7 +18,9 @@ package cgroups
 
 import (
 	"fmt"
+	"github.com/containerd/cgroups"
 	"github.com/golang/glog"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"io"
 	"os"
 	"path"
@@ -167,4 +169,21 @@ func (c *Controller) CgroupExists(ctl string, cgPath string) bool {
 	glog.V(5).Infof("Cgroup path check with error: %v", err)
 	return true
 
+}
+
+// function to create a new Cgroup
+func CreateChildCgroup(cgParent string, cgName string, res *specs.LinuxResources) (cgroups.Cgroup, error) {
+	parent, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgParent))
+	if err != nil {
+		glog.Errorf("Failed to load parent cgroup %v. error %v", cgParent, err)
+		return nil, err
+	}
+
+	cg, err := parent.New(cgName, res)
+	if err != nil {
+		glog.Errorf("Failed to create the child cgroup %v. error %v", cgName, err)
+		return nil, err
+	}
+
+	return cg, nil
 }


### PR DESCRIPTION
## what is the PR:
1. VM to match container in CG layout: i.e. POD/VMID/QemuProcess
2. Intro CG package from containerd for CG in vm runtime code base

## Why do we need it:
this will unify the CG management for VM and container workloads. with the well tested CG lib, it will be make future CG work easier and with good quality

## Testing done:
Adhoc testing for deployment, and VM orchestration.

## Note to CR:
A few options has been evaluated and the current one is the winner:
1. change the k8s CG creation naming with .partition as suffix for each level, and use libvirt domain.Resource.Partition to specify the CG parent for the qemu process. this seems to be best way from the runtime's perspective. However this will requires the k8s naming change and could impact other components; the current virtlet uses the customerized emulator process and  will requires the qemu process move to designated CG anyways. so this option is finally dropped.
2. create the desired CG during the "startContainer" call. this is the same workflow in the other runtime implementations such as containerd, docker etc. k8s set up the CG at the pod level and let the runtime service to setup the container level. current OCI spec also indicated that.
3. Copy properries from machine/qemu-xxx-libvirt-qemu CG to kubepods/podxxx/ vs set up new CG. this is fine either way. currently it is created with the properties set from the domainxml.

========== local test shows the CG for the vm ===========
##VM yaml file:
```
apiVersion: v1
kind: Pod
metadata:
  name: vmdefault
spec:
  virtualMachine:
    keyPairName: "foobar"
    name: vm
    image: download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
    imagePullPolicy: IfNotPresent
    resources:
      limits:
        cpu: "2"
        memory: "200Mi"
      requests:
        cpu: "1"
        memory: "200Mi"
```
## VM CG and settings:
```
root@ip-172-31-11-43:/sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6# cat cpu.shares 
1024
root@ip-172-31-11-43:/sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6# cat cpu.cfs_quota_us 
200000
root@ip-172-31-11-43:/sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6# cat cpu.cfs_period_us 
100000
root@ip-172-31-11-43:/sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6# cd /sys/fs/cgroup/memory/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6
root@ip-172-31-11-43:/sys/fs/cgroup/memory/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6# cat memory.limit_in_bytes 
209715200
root@ip-172-31-11-43:/sys/fs/cgroup/memory/kubepods/burstable/pod4a7d1e60-145f-442e-bebc-4dc5f76e1ff5/2de668de-182c-5ea8-4f0d-9989a248cbd6#
```