### PR TITLE
VM runtime CG update for vertical scaling support 

### DIFF
--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -271,6 +271,16 @@ func (domain *libvirtDomain) RestoreToSnapshot(snapshotID string) error {
 	return snapshot.RevertToSnapshot(0)
 }
 
+// Update domain vcpu
+func (domain *libvirtDomain) SetVcpus(vcpus uint) error {
+	return domain.d.SetVcpusFlags(vcpus, libvirt.DOMAIN_VCPU_CONFIG|libvirt.DOMAIN_VCPU_LIVE)
+}
+
+// Update domain current memory
+func (domain *libvirtDomain) SetCurrentMemory(memInKib uint64) error {
+	return domain.d.SetMemoryFlags(memInKib, libvirt.DOMAIN_MEM_CONFIG|libvirt.DOMAIN_MEM_LIVE)
+}
+
 type libvirtSecret struct {
 	s *libvirt.Secret
 }

--- a/pkg/manager/cri.go
+++ b/pkg/manager/cri.go
@@ -251,6 +251,12 @@ func ContainerInfoToCRIContainerStatus(in *types.ContainerInfo) *kubeapi.Contain
 		Annotations: in.Config.ContainerAnnotations,
 		Mounts:      mounts,
 		LogPath:     filepath.Join(in.Config.LogDirectory, in.Config.LogPath),
+		Resources:   &kubeapi.LinuxContainerResources{
+			CpuPeriod: in.Config.CPUPeriod,
+			CpuShares: in.Config.CPUShares,
+			CpuQuota:  in.Config.CPUQuota,
+			MemoryLimitInBytes: in.Config.MemoryLimitInBytes,
+		},
 		// TODO: FinishedAt, Reason, Message
 	}
 }

--- a/pkg/utils/cgroups/controllers.go
+++ b/pkg/utils/cgroups/controllers.go
@@ -171,7 +171,7 @@ func (c *Controller) CgroupExists(ctl string, cgPath string) bool {
 
 }
 
-// function to create a new Cgroup
+// Create a new CGroup with desired resource settings
 func CreateChildCgroup(cgParent string, cgName string, res *specs.LinuxResources) (cgroups.Cgroup, error) {
 	parent, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgParent))
 	if err != nil {
@@ -186,4 +186,22 @@ func CreateChildCgroup(cgParent string, cgName string, res *specs.LinuxResources
 	}
 
 	return cg, nil
+}
+
+// Update a CGroup with desired resource settings
+func UpdateVmCgroup(cgPath string, res *specs.LinuxResources) error {
+	glog.V(4).Infof("Update VM Cgroup: %v, with resource %v", cgPath, res)
+	cg, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgPath))
+	if err != nil {
+		glog.Errorf("Failed to load cgroup %v. error %v", cgPath, err)
+		return err
+	}
+
+	err = cg.Update(res)
+	if err != nil {
+		glog.Errorf("Failed to update cgroup %v. error %v", cgPath, err)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -117,4 +117,8 @@ type Domain interface {
 	CreateSnapshot(string) error
 	// RestoreToSnapshot restores current domain to the specified snapshot
 	RestoreToSnapshot(string) error
+	// Update vcpu for a give domain
+	SetVcpus(uint) error
+	// Update current memory for a given domain
+	SetCurrentMemory(uint64) error
 }


### PR DESCRIPTION
## What is in this PR:
Initial implementation for VM CG update to support vertical scaling in VM. note that the vm config and domain change will be in a separated PR.

## Why this PR is needed:
CG property update per the changes in the UpdataContainerResource() call, which is decided by the Arktos Agent.

## Special note to CR:
VM domain def and Config update will be in separated PR
Arktos Agent change will be a PR to the Arktos repo

## Testing done for this PR:
Ad hoc VM creation 

### Resize CPU:

root@ip-172-31-11-43:/# virsh dumpxml 1
<domain type='qemu' id='1' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
  <name>virtlet-3a8bf096-e3a3-vm</name>
  <uuid>3a8bf096-e3a3-5626-557a-ef78be7b6768</uuid>
  <memory unit='KiB'>209715200</memory>
  <currentMemory unit='KiB'>209715200</currentMemory>
  <vcpu placement='static' current='2'>4</vcpu>
  <cputune>
    <shares>2048</shares>
    <period>100000</period>
    <quota>100000</quota>
  </cputune>

root@ip-172-31-11-43:/# virsh setvcpus 1 3 --live --config

root@ip-172-31-11-43:/# virsh dumpxml 1
<domain type='qemu' id='1' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
  <name>virtlet-3a8bf096-e3a3-vm</name>
  <uuid>3a8bf096-e3a3-5626-557a-ef78be7b6768</uuid>
  <memory unit='KiB'>209715200</memory>
  <currentMemory unit='KiB'>209715200</currentMemory>
  <vcpu placement='static' current='3'>4</vcpu>
  <vcpus>
    <vcpu id='0' enabled='yes' hotpluggable='no' order='1'/>
    <vcpu id='1' enabled='yes' hotpluggable='no' order='2'/>
    <vcpu id='2' enabled='yes' hotpluggable='yes' order='3'/>
    <vcpu id='3' enabled='no' hotpluggable='yes'/>
  </vcpus>
  <cputune>
    <shares>2048</shares>
    <period>100000</period>
    <quota>100000</quota>
  </cputune>

root@ip-172-31-11-43:/# virsh dominfo 1
Id:             1
Name:           virtlet-3a8bf096-e3a3-vm
UUID:           3a8bf096-e3a3-5626-557a-ef78be7b6768
OS Type:        hvm
State:          running
CPU(s):         3
CPU time:       47.1s
Max memory:     209715200 KiB
Used memory:    209715200 KiB
Persistent:     yes
Autostart:      disable
Managed save:   no
Security model: none
Security DOI:   0

### issues in reducing CPUs:
root@ip-172-31-11-43:/# virsh setvcpus 1 2 --live --config
error: operation failed: vcpu unplug request timed out

root@ip-172-31-11-43:/# 