### PR TITLE
 cleanup node label and image mapping for Arktos

### DIFF
--- a/deploy/data/virtlet-ds.yaml
+++ b/deploy/data/virtlet-ds.yaml
@@ -26,17 +26,6 @@ spec:
       hostPID: true
       # bootstrap procedure needs to create a configmap in kube-system namespace
       serviceAccountName: virtlet
-
-      # only run Virtlet pods on the nodes with extraRuntime=virtlet label
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: extraRuntime
-                operator: In
-                values:
-                - virtlet
       imagePullSecrets:
       - name: repo-arktosstaging
       initContainers:
@@ -213,8 +202,6 @@ spec:
           mountPropagation: Bidirectional
         - name: vms-log
           mountPath: /var/log/vms
-        - mountPath: /etc/virtlet/images
-          name: image-name-translations
         - name: pods-log
           mountPath: /var/log/pods
         # needed for diagnostic purposes
@@ -312,9 +299,6 @@ spec:
       - hostPath:
           path: /etc/libvirt/qemu
         name: qemu
-      - configMap:
-          name: virtlet-image-translations
-        name: image-name-translations
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## What is the PR:
Cleanup the unneeded settings: nodel label, image translation configmap

## Why it is needed:
Remove unneeded code

## Special note to CR:
None. corresponding changes for arktos setup scripts in Arktos PR as well