### PR TITLE
Memory scale up and down with memory hotplug model and Libvirt APIs

### DIFF
--- a/cmd/vmwrapper/vmwrapper.go
+++ b/cmd/vmwrapper/vmwrapper.go
@@ -35,7 +35,8 @@ import (
 
 const (
 	fdSocketPath    = "/var/lib/virtlet/tapfdserver.sock"
-	defaultEmulator = "/usr/bin/qemu-system-x86_64" // FIXME
+	// default to the qemu built in vm runtime
+	defaultEmulator = "/usr/local/bin/qemu-system-x86_64" 
 	vmsProcFile     = "/var/lib/virtlet/vms.procfile"
 )
 

--- a/deploy/SetupVmruntime.sh
+++ b/deploy/SetupVmruntime.sh
@@ -56,6 +56,7 @@ cleanup() {
 	echo "Delete vm runtime meta data files"
 	rm -f -r /var/lib/virtlet/
 	rm -f -r /var/log/virtlet/
+	rm -f /var/run/libvirt/libvirt-sock
 }
 
 downloadRuntimeDeploymentFiles() {

--- a/images/Dockerfile.arktosvmruntime-base
+++ b/images/Dockerfile.arktosvmruntime-base
@@ -11,7 +11,7 @@ RUN echo deb-src http://archive.ubuntu.com/ubuntu/ bionic main universe restrict
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get -y build-dep libguestfs && \
     apt-get -y build-dep supermin && \
-    apt-get install -y apt-utils git libjansson-dev libhivex-ocaml-dev libguestfs-tools 
+    apt-get install -y apt-utils curl git libjansson-dev libhivex-ocaml-dev libguestfs-tools 
 
 # build libvirt 6.5.0
 RUN apt-get install -y build-essential libsasl2-dev libdevmapper-dev libgnutls28-dev \
@@ -30,22 +30,23 @@ RUN apt-get install -y build-essential libsasl2-dev libdevmapper-dev libgnutls28
     make clean
 
 # build qemu 5.0.0
-RUN apt-get build-dep -y qemu && \
+RUN apt-get -y update && \
+    apt-get build-dep -y qemu && \
     apt-get install -y checkinstall && \
     curl -O https://download.qemu.org/qemu-5.0.0.tar.xz && \
-    tar -xf qemu-5.0.0.tar.xz && \
+    tar -xvf qemu-5.0.0.tar.xz && \
     cd qemu-5.0.0 && \
-    ./configure && \
+    ./configure --target-list=x86_64-softmmu,x86_64-linux-user --cpu=x86_64 && \
     make && \
-    checkinstall make install && \
+    checkinstall  --nodoc --backup=no make install && \
     apt-get install ./*.deb && \
     make clean
 
 RUN apt-get install -y openssl scrub syslinux \
-                       apt-utils netbase iptables ebtables vncsnapshot \
+                       netbase iptables ebtables vncsnapshot \
                        socat netcat-openbsd \
                        acl attr binutils bsdmainutils btrfs-tools \
-                       bzip2 cpio cryptsetup curl dosfstools extlinux \
+                       bzip2 cpio cryptsetup dosfstools extlinux \
                        file gawk gdisk genisoimage iproute2 \
                        isc-dhcp-client kmod less libaugeas0 \
                        bridge-utils \

--- a/pkg/libvirttools/TestContainerLifecycle.out.yaml
+++ b/pkg/libvirttools/TestContainerLifecycle.out.yaml
@@ -27,7 +27,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -88,7 +88,7 @@
     </domain>
 - name: 'domain conn: ListDomains'
   value:
-  - virtlet-231700d5-c9a6-container1
+  - arktosRT--231700d5-c9a6-container1
 - name: container list after the container is created
   value:
   - Config:
@@ -142,8 +142,8 @@
     Name: container1
     StartedAt: 0
     State: 0
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -203,7 +203,7 @@
     Name: container1
     StartedAt: 1496175541000000000
     State: 1
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Shutdown'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Shutdown'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: container info after the container is stopped
@@ -259,7 +259,7 @@
     Name: container1
     StartedAt: 1496175541000000000
     State: 2
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'domain conn: ListDomains'

--- a/pkg/libvirttools/TestDomainDefinitions__9pfs_volume.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__9pfs_volume.out.yaml
@@ -39,7 +39,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -102,8 +102,8 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -121,8 +121,8 @@
           if ! mountpoint /var/lib/foobar; then mkdir -p /var/lib/foobar && mount -t 9p -o trans=virtio foobar /var/lib/foobar; fi
         path: /etc/cloud/mount-volumes.sh
         permissions: "0755"
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: Unmount

--- a/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__ceph_flexvolume.out.yaml
@@ -34,7 +34,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -104,8 +104,8 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -121,8 +121,8 @@
           if ! mountpoint /var/lib/whatever; then mkdir -p /var/lib/whatever && mount /dev/`ls /sys/devices/pci0000:00/0000:00:01.0/virtio*/host*/target*:0:0/*:0:0:1/block/`1 /var/lib/whatever; fi
         path: /etc/cloud/mount-volumes.sh
         permissions: "0755"
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'domain conn: secret libvirt-231700d5-c9a6-5a49-738d-99a954c51550-ceph: Remove'

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,15 +84,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0","public-keys":["key1","key2"]}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__cloud-init_with_user_data.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,8 +84,8 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0","public-keys":["key1","key2"]}'
     network-config: |
@@ -94,7 +94,7 @@
       #cloud-config
       users:
       - name: cloudy
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__file_injection.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__file_injection.out.yaml
@@ -30,7 +30,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -89,15 +89,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__file_injection_on_persistent_rootfs.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__file_injection_on_persistent_rootfs.out.yaml
@@ -20,7 +20,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -79,14 +79,14 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: CMD
   value:
     cmd: dmsetup remove virtlet-dm-231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__persistent_rootfs.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__persistent_rootfs.out.yaml
@@ -15,7 +15,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -74,14 +74,14 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: CMD
   value:
     cmd: dmsetup remove virtlet-dm-231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__plain_domain.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__plain_domain.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,15 +84,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__raw_block_volume.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_block_volume.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -90,8 +90,8 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -107,7 +107,7 @@
           ln -fs /dev/`ls /sys/devices/pci0000:00/0000:00:01.0/virtio*/host*/target*:0:0/*:0:0:1/block/` /dev/tst
         path: /etc/cloud/symlink-devs.sh
         permissions: "0755"
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__raw_devices.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__raw_devices.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -90,15 +90,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__system_UUID.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__system_UUID.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-53008994-44c0-container1</name>
+      <name>arktosRT--53008994-44c0-container1</name>
       <uuid>53008994-44c0-4017-ad44-9c49758083da</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -87,15 +87,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-53008994-44c0-container1: Create'
-- name: 'domain conn: virtlet-53008994-44c0-container1: iso image'
+- name: 'domain conn: arktosRT--53008994-44c0-container1: Create'
+- name: 'domain conn: arktosRT--53008994-44c0-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-53008994-44c0-container1: Destroy'
-- name: 'domain conn: virtlet-53008994-44c0-container1: Undefine'
+- name: 'domain conn: arktosRT--53008994-44c0-container1: Destroy'
+- name: 'domain conn: arktosRT--53008994-44c0-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_53008994-44c0-4017-ad44-9c49758083da

--- a/pkg/libvirttools/TestDomainDefinitions__vcpu_count.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__vcpu_count.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,15 +84,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__virtio_disk_driver.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,15 +84,15 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainDefinitions__volumes.out.yaml
+++ b/pkg/libvirttools/TestDomainDefinitions__volumes.out.yaml
@@ -58,7 +58,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -135,16 +135,16 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
       version: 1
     user-data: |
       #cloud-config
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'storage: volumes: RemoveVolumeByName'

--- a/pkg/libvirttools/TestDomainForcedShutdown.out.yaml
+++ b/pkg/libvirttools/TestDomainForcedShutdown.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -84,8 +84,8 @@
         <env name="VIRTLET_CONTAINER_LOG_PATH" value="/var/log/pods/69eec606-0493-5825-73a4-c5e0c0236155/container1_42.log"></env>
       </commandline>
     </domain>
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -93,16 +93,16 @@
     user-data: |
       #cloud-config
 - name: invoking StopContainer()
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Shutdown'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Shutdown'
   value:
     ignored: true
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Shutdown'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Shutdown'
   value:
     ignored: true
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Shutdown'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Shutdown'
   value:
     ignored: true
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Destroy'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: container info after the container is stopped
@@ -159,6 +159,6 @@
     StartedAt: 1496175541000000000
     State: 2
 - name: invoking RemoveContainer()
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainResourceConstraints.out.yaml
+++ b/pkg/libvirttools/TestDomainResourceConstraints.out.yaml
@@ -1,7 +1,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2410</maxMemory>
       <memory unit="KiB">1205</memory>

--- a/pkg/libvirttools/TestDump.out.yaml
+++ b/pkg/libvirttools/TestDump.out.yaml
@@ -1,8 +1,8 @@
 children:
-  domain-virtlet-231700d5-c9a6-container1:
+  domain-arktosRT--231700d5-c9a6-container1:
     data: |-
       <domain type="kvm">
-        <name>virtlet-231700d5-c9a6-container1</name>
+        <name>arktosRT--231700d5-c9a6-container1</name>
         <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
         <maxMemory unit="KiB" slots="16">2097152</maxMemory>
         <memory unit="KiB">1048576</memory>
@@ -63,7 +63,7 @@ children:
       </domain>
     ext: xml
     isdir: false
-    name: domain-virtlet-231700d5-c9a6-container1
+    name: domain-arktosRT--231700d5-c9a6-container1
   pool-volumes:
     data: |-
       <pool type="dir">

--- a/pkg/libvirttools/TestUpdateCpusets.out.yaml
+++ b/pkg/libvirttools/TestUpdateCpusets.out.yaml
@@ -25,7 +25,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -99,11 +99,11 @@
   - /sys/fs/cgroup/cpuset/somepath/in/cgroups/emulator/cpuset.cpus
   - "42"
 - name: Calling setting cpuset for domain definition
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container1</name>
+      <name>arktosRT--231700d5-c9a6-container1</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -164,6 +164,6 @@
       </commandline>
     </domain>
 - name: Invoking RemoveContainer()
-- name: 'domain conn: virtlet-231700d5-c9a6-container1: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/manager/TestCRIMounts.out.yaml
+++ b/pkg/manager/TestCRIMounts.out.yaml
@@ -140,7 +140,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container-for-testName_0</name>
+      <name>arktosRT--231700d5-c9a6-container-for-testName_0</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -237,8 +237,8 @@
 - name: 'enter: StartContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -272,7 +272,7 @@
 - name: 'enter: StopContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Destroy'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'storage: volumes: RemoveVolumeByName'
@@ -282,7 +282,7 @@
 - name: 'enter: RemoveContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'storage: volumes: RemoveVolumeByName'

--- a/pkg/manager/TestCRIPods.out.yaml
+++ b/pkg/manager/TestCRIPods.out.yaml
@@ -153,7 +153,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-231700d5-c9a6-container-for-testName_0</name>
+      <name>arktosRT--231700d5-c9a6-container-for-testName_0</name>
       <uuid>231700d5-c9a6-5a49-738d-99a954c51550</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -219,7 +219,7 @@
   value: {}
 - name: 'domain conn: ListDomains'
   value:
-  - virtlet-231700d5-c9a6-container-for-testName_0
+  - arktosRT--231700d5-c9a6-container-for-testName_0
 - name: 'leave: ListContainers'
   value:
     containers:
@@ -264,8 +264,8 @@
 - name: 'enter: StartContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Create'
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: iso image'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Create'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: iso image'
   value:
     meta-data: '{"instance-id":"testName_0.default","local-hostname":"testName_0"}'
     network-config: |
@@ -340,7 +340,7 @@
   value: {}
 - name: 'domain conn: ListDomains'
   value:
-  - virtlet-231700d5-c9a6-container-for-testName_0
+  - arktosRT--231700d5-c9a6-container-for-testName_0
 - name: 'leave: ListContainerStats'
   value:
     stats:
@@ -459,7 +459,7 @@
 - name: 'domain conn: DefineDomain'
   value: |-
     <domain type="kvm">
-      <name>virtlet-6b94d9a7-e22a-container-for-testName_1</name>
+      <name>arktosRT--6b94d9a7-e22a-container-for-testName_1</name>
       <uuid>6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0</uuid>
       <maxMemory unit="KiB" slots="16">2097152</maxMemory>
       <memory unit="KiB">1048576</memory>
@@ -554,8 +554,8 @@
   value: {}
 - name: 'domain conn: ListDomains'
   value:
-  - virtlet-231700d5-c9a6-container-for-testName_0
-  - virtlet-6b94d9a7-e22a-container-for-testName_1
+  - arktosRT--231700d5-c9a6-container-for-testName_0
+  - arktosRT--6b94d9a7-e22a-container-for-testName_1
 - name: 'leave: ListContainers'
   value:
     containers:
@@ -616,8 +616,8 @@
 - name: 'enter: StartContainer'
   value:
     container_id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
-- name: 'domain conn: virtlet-6b94d9a7-e22a-container-for-testName_1: Create'
-- name: 'domain conn: virtlet-6b94d9a7-e22a-container-for-testName_1: iso image'
+- name: 'domain conn: arktosRT--6b94d9a7-e22a-container-for-testName_1: Create'
+- name: 'domain conn: arktosRT--6b94d9a7-e22a-container-for-testName_1: iso image'
   value:
     meta-data: '{"instance-id":"testName_1.default","local-hostname":"testName_1"}'
     network-config: |
@@ -667,7 +667,7 @@
 - name: 'enter: StopContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Destroy'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Destroy'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'leave: StopContainer'
@@ -675,7 +675,7 @@
 - name: 'enter: StopContainer'
   value:
     container_id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
-- name: 'domain conn: virtlet-6b94d9a7-e22a-container-for-testName_1: Destroy'
+- name: 'domain conn: arktosRT--6b94d9a7-e22a-container-for-testName_1: Destroy'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
 - name: 'leave: StopContainer'
@@ -683,7 +683,7 @@
 - name: 'enter: StopContainer'
   value:
     container_id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
-- name: 'domain conn: virtlet-6b94d9a7-e22a-container-for-testName_1: Destroy'
+- name: 'domain conn: arktosRT--6b94d9a7-e22a-container-for-testName_1: Destroy'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
 - name: 'leave: StopContainer'
@@ -692,8 +692,8 @@
   value: {}
 - name: 'domain conn: ListDomains'
   value:
-  - virtlet-231700d5-c9a6-container-for-testName_0
-  - virtlet-6b94d9a7-e22a-container-for-testName_1
+  - arktosRT--231700d5-c9a6-container-for-testName_0
+  - arktosRT--6b94d9a7-e22a-container-for-testName_1
 - name: 'leave: ListContainers'
   value:
     containers:
@@ -757,7 +757,7 @@
 - name: 'enter: RemoveContainer'
   value:
     container_id: 231700d5-c9a6-5a49-738d-99a954c51550
-- name: 'domain conn: virtlet-231700d5-c9a6-container-for-testName_0: Undefine'
+- name: 'domain conn: arktosRT--231700d5-c9a6-container-for-testName_0: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_231700d5-c9a6-5a49-738d-99a954c51550
 - name: 'imageStore: GC'
@@ -768,7 +768,7 @@
 - name: 'enter: RemoveContainer'
   value:
     container_id: 6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
-- name: 'domain conn: virtlet-6b94d9a7-e22a-container-for-testName_1: Undefine'
+- name: 'domain conn: arktosRT--6b94d9a7-e22a-container-for-testName_1: Undefine'
 - name: 'storage: volumes: RemoveVolumeByName'
   value: virtlet_root_6b94d9a7-e22a-5d08-65ee-16b9b1e07ab0
 - name: 'imageStore: GC'

--- a/pkg/manager/runtime.go
+++ b/pkg/manager/runtime.go
@@ -403,6 +403,7 @@ func (v *VirtletRuntimeService) ListContainers(ctx context.Context, in *kubeapi.
 
 // ContainerStatus method implements ContainerStatus from CRI.
 func (v *VirtletRuntimeService) ContainerStatus(ctx context.Context, in *kubeapi.ContainerStatusRequest) (*kubeapi.ContainerStatusResponse, error) {
+	//TODO: consider add a lock to avoid the Sync function runs during the UpdateContainerResource
 	info, err := v.virtTool.SyncContainerInfoWithLibvirtDomain(in.ContainerId)
 	if err != nil {
 		return nil, err
@@ -471,6 +472,7 @@ func (v *VirtletRuntimeService) UpdateContainerResources(ctx context.Context, re
 	// TODO: should revert the CG update if the update domain resource function failed
 	err = v.virtTool.UpdateDomainResources(containerId, lcr)
 	if err != nil {
+		glog.V(4).Infof("Update Domain Resource failed with error: %v", err)
 		return nil, err
 	}
 

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -117,8 +117,8 @@ type Domain interface {
 	CreateSnapshot(string) error
 	// RestoreToSnapshot restores current domain to the specified snapshot
 	RestoreToSnapshot(string) error
-	// Update vcpu for a give domain
+	// Update vcpus for a give domain
 	SetVcpus(uint) error
-	// Update current memory for a given domain
-	SetCurrentMemory(uint64) error
+	// Update the domain memory with request to scale up or scale down the VM
+	AdjustDomainMemory(int64) error
 }

--- a/pkg/virt/fake/fake_domain.go
+++ b/pkg/virt/fake/fake_domain.go
@@ -332,7 +332,7 @@ func (d *FakeDomain) SetVcpus(vcpus uint) error {
 }
 
 // Update domain current memory
-func (d *FakeDomain) SetCurrentMemory(memInKib uint64) error {
+func (d *FakeDomain) AdjustDomainMemory(memChangeInKib int64) error {
 	return fmt.Errorf("not implenmented")
 }
 


### PR DESCRIPTION
## What is the PR for:
Enable runtime with libvirt 6.5.0 and Qemu 5.0.0
Memory scale up and down with memory hotplug model and Libvirt APIs

## Why does this PR needed:
Support Memory vertical scaling

## Special note to CR:

## Testing done:
   ### create VM with Ubuntu 18.04 image
    apiVersion: v1
    kind: Pod
    metadata:
      name: vmubuntu
      annotations:
        VirtletCPUModel: "host-model"
    spec:
      virtualMachine:
        keyPairName: "foobar"
        name: vmubuntu
        image: "cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
        imagePullPolicy: IfNotPresent
        resources:
          limits:
            cpu: "2"
            memory: "4Gi"
          requests:
            cpu: "2"
            memory: "4Gi"
     
   ### increase memory       
    kubectl patch pod vmubuntu --patch '{"spec":{"virtualMachine":{"name":"vmubuntu", "resources":{"requests":{"memory":"4.125Gi"}, "limits":{"memory":"4.125Gi"}}}}}'

    virsh # dominfo 1
    Id:             1
    Name:           virtlet-f350cc21-da2d-vmubuntu
    UUID:           f350cc21-da2d-5b0f-5e0c-67024a940bcd
    OS Type:        hvm
    State:          running
    CPU(s):         2
    CPU time:       802.3s
    Max memory:     4325376 KiB
    Used memory:    4325376 KiB
    Persistent:     yes
    Autostart:      disable
    Managed save:   no
    Security model: none
    Security DOI:   0
    
    
   ### decrease memory
    kubectl patch pod vmubuntu --patch '{"spec":{"virtualMachine":{"name":"vmubuntu", "resources":{"requests":{"memory":"4Gi"}, "limits":{"memory":"4Gi"}}}}}'
    
    virsh # dominfo 1
    Id:             1
    Name:           virtlet-f350cc21-da2d-vmubuntu
    UUID:           f350cc21-da2d-5b0f-5e0c-67024a940bcd
    OS Type:        hvm
    State:          running
    CPU(s):         2
    CPU time:       911.3s
    Max memory:     4194304 KiB
    Used memory:    4194304 KiB
    Persistent:     yes
    Autostart:      disable
    Managed save:   no
    Security model: none
    Security DOI:   0

   ### vm runtime log shows after a couple failures(due to memory reallocation), memory was unplugged
    I0726 23:42:34.646776   13930 runtime.go:452] Update Container Resources : &UpdateContainerResourcesRequest{ContainerId:f350cc21-da2d-5b0f-5e0c-67024a940bcd,Linux:&LinuxContainerResources{CpuPeriod:100000,CpuQuota:200000,CpuShares:2048,MemoryLimitInBytes:4294967296,OomScoreAdj:-998,CpusetCpus:,CpusetMems:,},}
    I0726 23:42:34.647834   13930 controllers.go:198] Update VM Cgroup: /kubepods/podbf9dff77-ea47-4040-a570-6d837b6e0a69/f350cc21-da2d-5b0f-5e0c-67024a940bcd, with resource &{[] 0xc420496800 0xc4205f4820 <nil> <nil> [] <nil> map[]}
    I0726 23:42:34.648997   13930 virtualization.go:1088] Update Domain Resources f350cc21-da2d-5b0f-5e0c-67024a940bcd, &LinuxContainerResources{CpuPeriod:100000,CpuQuota:200000,CpuShares:2048,MemoryLimitInBytes:4294967296,OomScoreAdj:-998,CpusetCpus:,CpusetMems:,}
    I0726 23:42:34.649207   13930 virtualization.go:1107] Update Domain Memory configuration
    I0726 23:42:34.650073   13930 virtualization.go:1182] Memory Info in KiB: current memory: 4325376, newMemory: 4194304. Max memory: 8388608
    I0726 23:42:34.650097   13930 virtualization.go:1189] Update domain memory in KiB: 4325376 -> 4194304
    I0726 23:42:34.650106   13930 libvirt_domain.go:315] MemoryChanges in KiB: -131072
    I0726 23:42:34.650113   13930 libvirt_domain.go:322] isAttach: false
    I0726 23:42:34.650120   13930 libvirt_domain.go:325] Number of device needed : 1
    I0726 23:42:34.650127   13930 libvirt_domain.go:334] Detach memory device to domain
    I0726 23:42:34.682321   13930 virtualization.go:1110] Update Domain Memory configuration failed with error: virError(Code=9, Domain=10, Message='operation failed: unplug of device was rejected by the guest')
    I0726 23:42:34.682357   13930 runtime.go:475] Update Domain Resource failed with error: virError(Code=9, Domain=10, Message='operation failed: unplug of device was rejected by the guest')
    E0726 23:42:34.682368   13930 grpc.go:117] FAIL: /runtime.v1alpha2.RuntimeService/UpdateContainerResources(): virError(Code=9, Domain=10, Message='operation failed: unplug of device was rejected by the guest')
    I0726 23:42:35.404797   13930 grpc.go:110] ENTER: /runtime.v1alpha2.RuntimeService/ContainerStatus():
    container_id: f350cc21-da2d-5b0f-5e0c-67024a940bcd
    I0726 23:42:35.404832   13930 virtualization.go:1204] Sync vm config with libvirt domain settings for VM: f350cc21-da2d-5b0f-5e0c-67024a940bcd
    I0726 23:42:35.405934   13930 virtualization.go:1215] domain info memory in KiB: memory: 4325376, memoryUnit: KiB, cpuShares: 2048, cpuQuota: 100000, cpuPeriod: 100000, vcpus: 2
    I0726 23:42:35.406119   13930 virtualization.go:1225] Runtime metadata config Memory in KiB: 4325376, CPUShares: 2048, CPUQuota: 200000, CPUPeriod: 100000
    I0726 23:42:35.406138   13930 virtualization.go:1259] All resource are in sync, return
    I0726 23:42:35.406517   13930 grpc.go:119] LEAVE: /runtime.v1alpha2.RuntimeService/ContainerStatus()
    status:
      annotations:
        io.kubernetes.container.hash: 9ce958e6
        io.kubernetes.container.restartCount: "0"
        io.kubernetes.container.terminationMessagePath: ""
        io.kubernetes.container.terminationMessagePolicy: ""
        io.kubernetes.pod.terminationGracePeriod: "30"
      created_at: 1595806766964695945
      id: f350cc21-da2d-5b0f-5e0c-67024a940bcd
      image:
        image: cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img@sha256:2aa09da85e513471ed7d0dad34f3745dd6c7cf67a0f1f92bee2443bea06932e0
      image_ref: cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img@sha256:2aa09da85e513471ed7d0dad34f3745dd6c7cf67a0f1f92bee2443bea06932e0
      labels:
        io.kubernetes.container.name: vmubuntu
        io.kubernetes.pod.name: vmubuntu
        io.kubernetes.pod.namespace: default
        io.kubernetes.pod.tenant: system
        io.kubernetes.pod.uid: bf9dff77-ea47-4040-a570-6d837b6e0a69
      log_path: /var/log/pods/system_default_vmubuntu_bf9dff77-ea47-4040-a570-6d837b6e0a69/vmubuntu/0.log
      metadata:
        name: vmubuntu
      mounts:
      - container_path: /etc/hosts
        host_path: /var/lib/kubelet/pods/bf9dff77-ea47-4040-a570-6d837b6e0a69/etc-hosts
      resources:
        cpu_period: 100000
        cpu_quota: 200000
        cpu_shares: 2048
        memory_limit_in_bytes: 4429185024
      started_at: 1595806767460000661
      state: 1


    I0726 23:43:50.792054   13930 runtime.go:452] Update Container Resources : &UpdateContainerResourcesRequest{ContainerId:f350cc21-da2d-5b0f-5e0c-67024a940bcd,Linux:&LinuxContainerResources{CpuPeriod:100000,CpuQuota:200000,CpuShares:2048,MemoryLimitInBytes:4294967296,OomScoreAdj:-998,CpusetCpus:,CpusetMems:,},}
    I0726 23:43:50.792849   13930 controllers.go:198] Update VM Cgroup: /kubepods/podbf9dff77-ea47-4040-a570-6d837b6e0a69/f350cc21-da2d-5b0f-5e0c-67024a940bcd, with resource &{[] 0xc420592f00 0xc4204014f0 <nil> <nil> [] <nil> map[]}
    I0726 23:43:50.794032   13930 virtualization.go:1088] Update Domain Resources f350cc21-da2d-5b0f-5e0c-67024a940bcd, &LinuxContainerResources{CpuPeriod:100000,CpuQuota:200000,CpuShares:2048,MemoryLimitInBytes:4294967296,OomScoreAdj:-998,CpusetCpus:,CpusetMems:,}
    I0726 23:43:50.794234   13930 virtualization.go:1107] Update Domain Memory configuration
    I0726 23:43:50.795054   13930 virtualization.go:1182] Memory Info in KiB: current memory: 4325376, newMemory: 4194304. Max memory: 8388608
    I0726 23:43:50.795068   13930 virtualization.go:1189] Update domain memory in KiB: 4325376 -> 4194304
    I0726 23:43:50.795076   13930 libvirt_domain.go:315] MemoryChanges in KiB: -131072
    I0726 23:43:50.795082   13930 libvirt_domain.go:322] isAttach: false
    I0726 23:43:50.795089   13930 libvirt_domain.go:325] Number of device needed : 1
    I0726 23:43:50.795095   13930 libvirt_domain.go:334] Detach memory device to domain
    I0726 23:43:55.447698   13930 grpc.go:110] ENTER: /runtime.v1alpha2.RuntimeService/ContainerStatus():
    container_id: f350cc21-da2d-5b0f-5e0c-67024a940bcd
    I0726 23:43:55.447747   13930 virtualization.go:1204] Sync vm config with libvirt domain settings for VM: f350cc21-da2d-5b0f-5e0c-67024a940bcd
    I0726 23:43:55.448860   13930 virtualization.go:1215] domain info memory in KiB: memory: 4325376, memoryUnit: KiB, cpuShares: 2048, cpuQuota: 100000, cpuPeriod: 100000, vcpus: 2
    I0726 23:43:55.449017   13930 virtualization.go:1225] Runtime metadata config Memory in KiB: 4325376, CPUShares: 2048, CPUQuota: 200000, CPUPeriod: 100000
    I0726 23:43:55.449027   13930 virtualization.go:1259] All resource are in sync, return
    I0726 23:43:55.449419   13930 grpc.go:119] LEAVE: /runtime.v1alpha2.RuntimeService/ContainerStatus()
