### PR TITLE
Skip kubelet call to update container resource while there is an async update in progress in libvirt

### DIFF
--- a/pkg/libvirttools/TestContainerLifecycle.out.yaml
+++ b/pkg/libvirttools/TestContainerLifecycle.out.yaml
@@ -136,6 +136,7 @@
       PodNamespace: default
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: fake-tenant
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: 231700d5-c9a6-5a49-738d-99a954c51550
@@ -197,6 +198,7 @@
       PodNamespace: default
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: fake-tenant
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: 231700d5-c9a6-5a49-738d-99a954c51550
@@ -253,6 +255,7 @@
       PodNamespace: default
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: fake-tenant
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: 231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/TestDomainForcedShutdown.out.yaml
+++ b/pkg/libvirttools/TestDomainForcedShutdown.out.yaml
@@ -152,6 +152,7 @@
       PodNamespace: default
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: fake-tenant
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: 231700d5-c9a6-5a49-738d-99a954c51550

--- a/pkg/libvirttools/event_handler.go
+++ b/pkg/libvirttools/event_handler.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 Authors of Arktos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirttools
+
+import (
+	"github.com/Mirantis/virtlet/pkg/metadata"
+	"github.com/Mirantis/virtlet/pkg/metadata/types"
+	"github.com/golang/glog"
+	"github.com/libvirt/libvirt-go"
+	"time"
+)
+
+// handle libvirt domain events
+// currently it is merely for the memory device add/remove event to avoid repeated calls of
+// UpdateContainerResources() from kubelet while a resource updating is in progress
+//
+type eventHandler struct {
+	uri       string
+	conn      *libvirt.Connect
+	metaStore metadata.ContainerStore
+}
+
+func init() {
+	libvirt.EventRegisterDefaultImpl()
+}
+
+func NewEventHandler(uri string, store metadata.Store) *eventHandler {
+	conn, err := libvirt.NewConnect(uri)
+	if err != nil {
+		glog.Errorf("failed to connect to %v", uri)
+		return nil
+	}
+
+	return &eventHandler{
+		uri:       uri,
+		conn:      conn,
+		metaStore: store,
+	}
+}
+
+// TODO: add failure handling logic in callback registration and handler logic
+//       deregister if needed in failed cases
+func (h *eventHandler) RegisterEventCallBacks() error {
+	var callbackId int
+	var err error
+
+	if callbackId, err = h.conn.DomainEventLifecycleRegister(nil, func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventLifecycle) {
+		id, _ := d.GetUUIDString()
+		glog.V(4).Infof("debug changes on Domain ID %v", id)
+
+	}); err != nil {
+		return err
+	}
+	glog.V(4).Infof("Registered domainLifecycleCallback returns %v, error: %v", callbackId, err)
+
+	if callbackId, err = h.conn.DomainEventDeviceAddedRegister(nil, func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventDeviceAdded) {
+		glog.V(4).Infof("Device added. DevAlias :%v", event.DevAlias)
+		handleMemoryDeviceAddRemove(d, h.metaStore)
+
+	}); err != nil {
+		return err
+	}
+	glog.V(4).Infof("Registered deviceAddedCallback returns %v, error: %v", callbackId, err)
+
+	if callbackId, err = h.conn.DomainEventDeviceRemovedRegister(nil, func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventDeviceRemoved) {
+		glog.V(4).Infof("Device removed. DevAlias :%v; string: %v", event.DevAlias, event.String())
+		handleMemoryDeviceAddRemove(d, h.metaStore)
+
+	}); err != nil {
+		return err
+	}
+	glog.V(4).Infof("Registered deviceRemovedCallback returns %v, error: %v", callbackId, err)
+
+	// if async hotplug/unplug failed, release the lock so kubelet retry can get in
+	if callbackId, err = h.conn.DomainEventDeviceRemovalFailedRegister(nil, func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventDeviceRemovalFailed) {
+		glog.V(4).Infof("Device removal failed. DevAlias :%v", event.DevAlias)
+		handleMemoryDeviceAddRemove(d, h.metaStore)
+	}); err != nil {
+		return err
+	}
+	glog.V(4).Infof("Registered deviceRemovalFailedCallback returns %v, error: %v", callbackId, err)
+
+	go func() {
+		for {
+			if res := libvirt.EventRunDefaultImpl(); res != nil {
+				glog.Errorf("Listening to libvirt events failed, retrying.")
+				time.Sleep(time.Second)
+			}
+		}
+	}()
+	glog.Infof("Listening to libvirt events......")
+	return nil
+}
+
+// take actions needed in the callback functions
+// keep synchronized pattern to reduce complexity for now
+// post 830, a channel can be added here to perform those actions
+func handleMemoryDeviceAddRemove(d *libvirt.Domain, metaStore metadata.ContainerStore) error {
+	id, err := d.GetUUIDString()
+	if err != nil {
+		return err
+	}
+
+	domInfo, err := d.GetInfo()
+	if err != nil {
+		return err
+	}
+
+	// Update the vm config and metadata stored in Arktos-vm-runtime metadata
+	containerInfo, err := metaStore.Container(id).Retrieve()
+	if err != nil {
+		return err
+	}
+
+	containerInfo.Config.MemoryLimitInBytes = int64(domInfo.Memory * defaultLibvirtDomainMemoryUnitValue)
+	containerInfo.Config.ResourceUpdateInProgress = false
+
+	glog.V(4).Infof("Update runtime metadata with config: %v", containerInfo.Config)
+	err = metaStore.Container(id).Save(
+		func(_ *types.ContainerInfo) (*types.ContainerInfo, error) {
+			return containerInfo, nil
+		})
+
+	if err != nil {
+		glog.Errorf("Failed to save containerInfo for container: %v", id)
+		return err
+	}
+
+	return nil
+
+}

--- a/pkg/libvirttools/libvirt_domain.go
+++ b/pkg/libvirttools/libvirt_domain.go
@@ -307,10 +307,6 @@ func determineNumberOfDeviceNeeded(memChangeInKib int64, isAttach bool) int {
 // the memory device is 512 Mib each
 func (domain *libvirtDomain) AdjustDomainMemory(memChangeInKib int64) error {
 	glog.V(4).Infof("MemoryChanges in KiB: %v", memChangeInKib)
-	// no memory changes, just return
-	if memChangeInKib == 0 {
-		return nil
-	}
 
 	isAttach := memChangeInKib > 0
 	glog.V(4).Infof("isAttach: %v", isAttach)

--- a/pkg/manager/TestConversions__ContainerInfoToCRIContainer.out.yaml
+++ b/pkg/manager/TestConversions__ContainerInfoToCRIContainer.out.yaml
@@ -24,6 +24,7 @@
       PodNamespace: ""
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: ""
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: f1bfb494-af3d-48ab-b8b1-2c850e1e8a00
@@ -69,6 +70,7 @@
       PodNamespace: ""
       PodSandboxID: d25ded14-d35d-510b-5749-f83cc165794e
       PodTenant: ""
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175560000000000
     Id: 13bdedae-540d-4131-959b-366c6343d5b4

--- a/pkg/manager/TestConversions__ContainerInfoToCRIContainerStatus.out.yaml
+++ b/pkg/manager/TestConversions__ContainerInfoToCRIContainerStatus.out.yaml
@@ -24,6 +24,7 @@
       PodNamespace: ""
       PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
       PodTenant: ""
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175540000000000
     Id: f1bfb494-af3d-48ab-b8b1-2c850e1e8a00
@@ -71,6 +72,7 @@
       PodNamespace: ""
       PodSandboxID: d25ded14-d35d-510b-5749-f83cc165794e
       PodTenant: ""
+      ResourceUpdateInProgress: false
       VolumeDevices: null
     CreatedAt: 1496175560000000000
     Id: 13bdedae-540d-4131-959b-366c6343d5b4

--- a/pkg/manager/TestConversions__GetVMConfig.out.yaml
+++ b/pkg/manager/TestConversions__GetVMConfig.out.yaml
@@ -54,6 +54,7 @@
     PodNamespace: default
     PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
     PodTenant: ""
+    ResourceUpdateInProgress: false
     VolumeDevices: null
 - in:
     config:
@@ -112,6 +113,7 @@
     PodNamespace: default
     PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
     PodTenant: ""
+    ResourceUpdateInProgress: false
     VolumeDevices: null
 - in:
     config:
@@ -175,4 +177,5 @@
     PodNamespace: default
     PodSandboxID: d25ded14-d35d-510b-5749-f83cc165794e
     PodTenant: ""
+    ResourceUpdateInProgress: false
     VolumeDevices: null

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -88,6 +88,12 @@ func (v *VirtletManager) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create metadata store: %v", err)
 	}
+
+	// Reset the resourceUpdateInProgress flag for existing containers
+	if v.metadataStore.ResetResourceUpdateInProgress() != nil {
+		return fmt.Errorf("failed to reset resourceUpdateInprogress flags in metadata store: %v", err)
+	}
+
 	v.diagSet.RegisterDiagSource("metadata", metadata.GetMetadataDumpSource(v.metadataStore))
 
 	downloader := image.NewDownloader(*v.config.DownloadProtocol)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -107,6 +107,15 @@ func (v *VirtletManager) Run() error {
 	}
 	v.diagSet.RegisterDiagSource("libvirt-xml", libvirttools.NewLibvirtDiagSource(conn, conn))
 
+	handler := libvirttools.NewEventHandler(*v.config.LibvirtURI, v.metadataStore)
+	if handler == nil {
+		return fmt.Errorf("failed to create libvirt event handler: %v", err)
+	}
+
+	if handler.RegisterEventCallBacks() != nil {
+		return fmt.Errorf("failed to create needed libvirt event callbacks: %v", err)
+	}
+
 	virtConfig := libvirttools.VirtualizationConfig{
 		DisableKVM:           *v.config.DisableKVM,
 		EnableSriov:          *v.config.EnableSriov,

--- a/pkg/metadata/TestDumpMetadata.out.txt
+++ b/pkg/metadata/TestDumpMetadata.out.txt
@@ -52,6 +52,7 @@ Sandboxes:
           PodNamespace: ""
           PodSandboxID: 69eec606-0493-5825-73a4-c5e0c0236155
           PodTenant: ""
+          ResourceUpdateInProgress: false
           VolumeDevices: null
         CreatedAt: 1531164300000000000
         Id: 1a122822-ebbf-527b-48b4-a96b1b75951b
@@ -112,6 +113,7 @@ Sandboxes:
           PodNamespace: ""
           PodSandboxID: d25ded14-d35d-510b-5749-f83cc165794e
           PodTenant: ""
+          ResourceUpdateInProgress: false
           VolumeDevices: null
         CreatedAt: 1531164300000000000
         Id: d59d8fe6-153f-5959-64a6-6817f77f867a

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -88,6 +88,8 @@ type Store interface {
 	SandboxStore
 	ContainerStore
 	io.Closer
+	// Reset the ResourceUpdateInProgress flag when runtime process restarts
+	ResetResourceUpdateInProgress() error
 }
 
 // NewPodSandboxInfo is a factory function for PodSandboxInfo instances

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -77,6 +77,10 @@ type ContainerStore interface {
 	// ImagesInUse returns a set of images in use by containers in the store.
 	// The keys of the returned map are image names and the values are always true.
 	ImagesInUse() (map[string]bool, error)
+	// Check if a resource setting being updated or not
+	ResourceUpdateInProgress(containerID string) (bool, error)
+	// Update the vmconfig.ResourceUpdateInProgress flag
+	SetResourceUpdateInProgress(containerID string, state bool) error
 }
 
 // Store provides single interface for metadata storage implementation

--- a/pkg/metadata/types/types.go
+++ b/pkg/metadata/types/types.go
@@ -283,6 +283,8 @@ type VMConfig struct {
 	LogPath string
 	// cgroup parent specified in the linuxPodsandboxconfig
 	CgroupParent string
+	// currently a resource is being updated
+	ResourceUpdateInProgress bool
 }
 
 // RootVolumeDevice returns the volume device that should be used for

--- a/pkg/virt/domain_interface.go
+++ b/pkg/virt/domain_interface.go
@@ -19,7 +19,6 @@ package virt
 
 import (
 	"errors"
-
 	libvirt "github.com/libvirt/libvirt-go"
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )


### PR DESCRIPTION
## What is this PR
skip repeated calls from kubelet while an async resource update is in progress for a given container.

## Why is it needed
given a case where plug/unplug and repeat cases. runtime could end up in unknown stage

## Special not to CR
A few changes in this PR at high level. currently they are restraint to be a "bugfix" level of code change for 830
1. an event handler for libvirt's async memory unplug/plug operations
2. a config metadata based locking mechanism
3. some minor code move for updating vm-runtime metadata.

## Testing done
Add hoc patching tests
