### PR TITLE
rollback qemu to 4.0.0 for setupvcpu issue

### DIFF
--- a/images/Dockerfile.arktosvmruntime
+++ b/images/Dockerfile.arktosvmruntime
@@ -1,7 +1,8 @@
 # TODO: generate this tag. unfortunately can't use ARG:
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 # (but add a note about it here for the future)
-FROM arktosstaging/vmruntime-base:v0.1
+# arktosstaging/vmruntime-base:v0.2 is with qemu 4.0.0 + libvirt 6.5.0
+FROM arktosstaging/vmruntime-base:v0.2
 MAINTAINER YunwenBai <yunwen.bai@futurewei.com>
 
 LABEL arktosstaging.image="arktosstaging"

--- a/images/Dockerfile.arktosvmruntime-base
+++ b/images/Dockerfile.arktosvmruntime-base
@@ -29,13 +29,13 @@ RUN apt-get install -y build-essential libsasl2-dev libdevmapper-dev libgnutls28
     make install && \
     make clean
 
-# build qemu 5.0.0
+# build qemu 4.0.0
 RUN apt-get -y update && \
     apt-get build-dep -y qemu && \
     apt-get install -y checkinstall && \
-    curl -O https://download.qemu.org/qemu-5.0.0.tar.xz && \
-    tar -xvf qemu-5.0.0.tar.xz && \
-    cd qemu-5.0.0 && \
+    curl -O https://download.qemu.org/qemu-4.0.0.tar.xz && \
+    tar -xvf qemu-4.0.0.tar.xz && \
+    cd qemu-4.0.0 && \
     ./configure --target-list=x86_64-softmmu,x86_64-linux-user --cpu=x86_64 && \
     make && \
     checkinstall  --nodoc --backup=no make install && \

--- a/pkg/libvirttools/virtualization.go
+++ b/pkg/libvirttools/virtualization.go
@@ -1095,14 +1095,13 @@ func (v *VirtualizationTool) UpdateDomainResources(vmID string, lcr *kubeapi.Lin
 	var cpuUpdated bool
 	var memUpdated bool
 
-	// TODO: enable this after CPU bug fix
-	//glog.V(4).Infof("Update Domain CPU configuration")
-	//err = v.updateDomainCPUs(domain, lcr)
-	//if err != nil {
-	//	glog.V(4).Infof("Update Domain CPU configuration failed with error: %v", err)
-	//	return err
-	//}
-	//cpuUpdated = true
+	glog.V(4).Infof("Update Domain CPU configuration")
+	err = v.updateDomainCPUs(domain, lcr)
+	if err != nil {
+		glog.V(4).Infof("Update Domain CPU configuration failed with error: %v", err)
+		return err
+	}
+	cpuUpdated = true
 
 	glog.V(4).Infof("Update Domain Memory configuration")
 	err = v.updateDomainMemory(domain, lcr)


### PR DESCRIPTION
## What is the PR:
Rollback to a bit earlier version of qemu, qemu 4.0.0, to avoid issue 52 in setupvcpu() failure in qemu
#52 

## Why is it needed:
enable cpu scale up

## Special note to CR:
none.

## Testing done:
Ad hoc tested